### PR TITLE
Face mesh Windows DLL desktop example

### DIFF
--- a/mediapipe/calculators/util/BUILD
+++ b/mediapipe/calculators/util/BUILD
@@ -19,6 +19,20 @@ licenses(["notice"])
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+    name = "counting_vector_size_calculator",
+    srcs = ["counting_vector_size_calculator.cc"],
+    hdrs = ["counting_vector_size_calculator.h"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//mediapipe/framework:calculator_framework",
+        "//mediapipe/framework/formats:landmark_cc_proto",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "alignment_points_to_rects_calculator",
     srcs = ["alignment_points_to_rects_calculator.cc"],
     visibility = ["//visibility:public"],

--- a/mediapipe/calculators/util/counting_vector_size_calculator.cc
+++ b/mediapipe/calculators/util/counting_vector_size_calculator.cc
@@ -1,0 +1,26 @@
+// Copyright 2020 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mediapipe/calculators/util/counting_vector_size_calculator.h"
+
+#include "mediapipe/framework/formats/landmark.pb.h"
+
+namespace mediapipe {
+
+typedef CountingVectorSizeCalculator<
+    std::vector<::mediapipe::NormalizedLandmarkList>>
+    CountingNormalizedLandmarkListVectorSizeCalculator;
+
+REGISTER_CALCULATOR(CountingNormalizedLandmarkListVectorSizeCalculator);
+} // namespace mediapipe

--- a/mediapipe/calculators/util/counting_vector_size_calculator.h
+++ b/mediapipe/calculators/util/counting_vector_size_calculator.h
@@ -1,0 +1,79 @@
+// Copyright 2020 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIAPIPE_CALCULATORS_UTIL_COUNTING_VECTOR_SIZE_CALCULATOR_H
+#define MEDIAPIPE_CALCULATORS_UTIL_COUNTING_VECTOR_SIZE_CALCULATOR_H
+
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/formats/landmark.pb.h"
+
+namespace mediapipe {
+
+// A calculator that counts the size of the input vector. It was created to
+// aid in polling packets in the output stream synchronously. If there is
+// a clock stream, it will output a value of 0 even if the input vector stream
+// is empty. If not, it will output some value only if there is an input vector.
+// The clock stream must have the same time stamp as the vector stream, and
+// it must be the stream where packets are transmitted while the graph is
+// running. (e.g. Any input stream of graph)
+//
+// It is designed to be used like:
+//
+// Example config:
+// node {
+//   calculator: "CountingWithVectorSizeCalculator"
+//   input_stream: "CLOCK:triger_signal"
+//   input_stream: "VECTOR:input_vector"
+//   output_stream: "COUNT:vector_count"
+// }
+//
+// node {
+//   calculator: "CountingWithVectorSizeCalculator"
+//   input_stream: "VECTOR:input_vector"
+//   output_stream: "COUNT:vector_count"
+// }
+
+template <typename VectorT>
+class CountingVectorSizeCalculator : public CalculatorBase {
+public:
+  static ::mediapipe::Status GetContract(CalculatorContract *cc) {
+    if (cc->Inputs().HasTag("CLOCK")) {
+      cc->Inputs().Tag("CLOCK").SetAny();
+    }
+
+    RET_CHECK(cc->Inputs().HasTag("VECTOR"));
+    cc->Inputs().Tag("VECTOR").Set<VectorT>();
+    RET_CHECK(cc->Outputs().HasTag("COUNT"));
+    cc->Outputs().Tag("COUNT").Set<int>();
+
+    return ::mediapipe::OkStatus();
+  }
+
+  ::mediapipe::Status Process(CalculatorContext *cc) {
+    std::unique_ptr<int> face_count;
+    if (!cc->Inputs().Tag("VECTOR").IsEmpty()) {
+      const auto &landmarks = cc->Inputs().Tag("VECTOR").Get<VectorT>();
+      face_count = absl::make_unique<int>(landmarks.size());
+    } else {
+      face_count = absl::make_unique<int>(0);
+    }
+    cc->Outputs().Tag("COUNT").Add(face_count.release(), cc->InputTimestamp());
+
+    return ::mediapipe::OkStatus();
+  };
+};
+
+} // namespace mediapipe
+
+#endif // MEDIAPIPE_CALCULATORS_UTIL_COUNTING_VECTOR_SIZE_CALCULATOR_H

--- a/mediapipe/examples/desktop/face_mesh_dll/BUILD
+++ b/mediapipe/examples/desktop/face_mesh_dll/BUILD
@@ -1,0 +1,65 @@
+# Copyright 2019 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("windows_dll_library.bzl", "windows_dll_library")
+
+licenses(["notice"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//examples:__pkg__"],
+)
+
+package(default_visibility = ["//mediapipe/examples:__subpackages__"])
+
+# Define the shared library
+windows_dll_library(
+    name = "face_mesh_lib",
+    srcs = ["face_mesh_lib.cpp"],
+    hdrs = ["face_mesh_lib.h"],
+    # Define COMPILING_DLL to export symbols during compiling the DLL.
+    copts = ["-DCOMPILING_DLL"],
+    deps = [
+        "//mediapipe/framework:calculator_framework",
+        "//mediapipe/framework/formats:image_frame",
+        "//mediapipe/framework/formats:image_frame_opencv",
+        "//mediapipe/framework/formats:landmark_cc_proto",
+        "//mediapipe/framework/port:file_helpers",
+        "//mediapipe/framework/port:opencv_highgui",
+        "//mediapipe/framework/port:opencv_imgproc",
+        "//mediapipe/framework/port:opencv_video",
+        "//mediapipe/framework/port:parse_text_proto",
+        "//mediapipe/framework/port:status",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+
+        "//mediapipe/calculators/core:constant_side_packet_calculator",
+        "//mediapipe/calculators/core:flow_limiter_calculator",
+        "//mediapipe/modules/face_landmark:face_landmark_front_cpu_with_face_counter",
+
+
+    ]
+)
+
+# **Implicitly link to face_mesh_lib.dll**
+
+## Link to face_mesh_lib.dll through its import library.
+cc_binary(
+    name = "face_mesh_cpu",
+    srcs = ["face_mesh_cpu.cpp"],
+    deps = [
+        ":face_mesh_lib",
+    ],
+)

--- a/mediapipe/examples/desktop/face_mesh_dll/face_mesh_cpu.cpp
+++ b/mediapipe/examples/desktop/face_mesh_dll/face_mesh_cpu.cpp
@@ -1,0 +1,56 @@
+#include "face_mesh_lib.h"
+
+int main(int argc, char **argv) {
+  google::InitGoogleLogging(argv[0]);
+  absl::ParseCommandLine(argc, argv);
+
+
+  cv::VideoCapture capture;
+  capture.open(0);
+  if (!capture.isOpened()) {
+    return -1;
+  }
+
+  constexpr char kWindowName[] = "MediaPipe";
+
+  cv::namedWindow(kWindowName, /*flags=WINDOW_AUTOSIZE*/ 1);
+#if (CV_MAJOR_VERSION >= 3) && (CV_MINOR_VERSION >= 2)
+  capture.set(cv::CAP_PROP_FRAME_WIDTH, 640);
+  capture.set(cv::CAP_PROP_FRAME_HEIGHT, 480);
+  capture.set(cv::CAP_PROP_FPS, 30);
+#endif
+
+  LOG(INFO) << "VideoCapture initialized.";
+
+  FaceMeshDetector *faceMeshDetector = FaceMeshDetector_Construct();
+
+  LOG(INFO) << "FaceMeshDetector constructed.";
+
+  LOG(INFO) << "Start grabbing and processing frames.";
+  bool grab_frames = true;
+
+  while (grab_frames) {
+    // Capture opencv camera.
+    cv::Mat camera_frame_raw;
+    capture >> camera_frame_raw;
+    if (camera_frame_raw.empty()) {
+      LOG(INFO) << "Ignore empty frames from camera.";
+      continue;
+    }
+    cv::Mat camera_frame;
+    cv::cvtColor(camera_frame_raw, camera_frame, cv::COLOR_BGR2RGB);
+    cv::flip(camera_frame, camera_frame, /*flipcode=HORIZONTAL*/ 1);
+
+    FaceMeshDetector_ProcessFrame(faceMeshDetector, camera_frame);
+
+    const int pressed_key = cv::waitKey(5);
+    if (pressed_key >= 0 && pressed_key != 255)
+      grab_frames = false;
+
+    cv::imshow(kWindowName, camera_frame_raw);
+  }
+
+  LOG(INFO) << "Shutting down.";
+
+  FaceMeshDetector_Destruct(faceMeshDetector);
+}

--- a/mediapipe/examples/desktop/face_mesh_dll/face_mesh_cpu.cpp
+++ b/mediapipe/examples/desktop/face_mesh_dll/face_mesh_cpu.cpp
@@ -4,7 +4,6 @@ int main(int argc, char **argv) {
   google::InitGoogleLogging(argv[0]);
   absl::ParseCommandLine(argc, argv);
 
-
   cv::VideoCapture capture;
   capture.open(0);
   if (!capture.isOpened()) {
@@ -41,7 +40,21 @@ int main(int argc, char **argv) {
     cv::cvtColor(camera_frame_raw, camera_frame, cv::COLOR_BGR2RGB);
     cv::flip(camera_frame, camera_frame, /*flipcode=HORIZONTAL*/ 1);
 
-    FaceMeshDetector_ProcessFrame(faceMeshDetector, camera_frame);
+    std::unique_ptr<std::vector<std::vector<cv::Point2f>>> multi_face_landmarks(
+        reinterpret_cast<std::vector<std::vector<cv::Point2f>> *>(
+            FaceMeshDetector_ProcessFrame2D(faceMeshDetector, camera_frame)));
+
+    const auto multi_face_landmarks_num = multi_face_landmarks->size();
+
+    LOG(INFO) << "Got multi_face_landmarks_num: " << multi_face_landmarks_num;
+
+    if (multi_face_landmarks_num) {
+      auto &face_landmarks = multi_face_landmarks->operator[](0);
+      auto &landmark = face_landmarks[0];
+
+      LOG(INFO) << "First landmark: x - " << landmark.x << ", y - "
+                << landmark.y;
+    }
 
     const int pressed_key = cv::waitKey(5);
     if (pressed_key >= 0 && pressed_key != 255)

--- a/mediapipe/examples/desktop/face_mesh_dll/face_mesh_lib.cpp
+++ b/mediapipe/examples/desktop/face_mesh_dll/face_mesh_lib.cpp
@@ -1,0 +1,179 @@
+#include <windows.h>
+
+#include "face_mesh_lib.h"
+
+#define DEBUG
+
+FaceMeshDetector::FaceMeshDetector() {
+  const auto status = InitFaceMeshDetector();
+  if (!status.ok()) {
+    LOG(INFO) << "Failed constructing FaceMeshDetector.";
+  }
+}
+
+absl::Status FaceMeshDetector::InitFaceMeshDetector() {
+  LOG(INFO) << "Get calculator graph config contents: " << graphConfig;
+
+  mediapipe::CalculatorGraphConfig config =
+      mediapipe::ParseTextProtoOrDie<mediapipe::CalculatorGraphConfig>(
+          graphConfig);
+
+  LOG(INFO) << "Initialize the calculator graph.";
+
+  MP_RETURN_IF_ERROR(graph.Initialize(config));
+
+  LOG(INFO) << "Start running the calculator graph.";
+
+  ASSIGN_OR_RETURN(mediapipe::OutputStreamPoller landmarks_poller,
+                   graph.AddOutputStreamPoller(kOutputStream_landmarks));
+  ASSIGN_OR_RETURN(mediapipe::OutputStreamPoller face_count_poller,
+                   graph.AddOutputStreamPoller(kOutputStream_faceCount));
+
+  landmarks_poller_ptr = std::make_unique<mediapipe::OutputStreamPoller>(
+      std::move(landmarks_poller));
+  face_count_poller_ptr = std::make_unique<mediapipe::OutputStreamPoller>(
+      std::move(face_count_poller));
+
+  MP_RETURN_IF_ERROR(graph.StartRun({}));
+
+  return absl::Status();
+}
+
+absl::Status FaceMeshDetector::ProcessFrameWithStatus(cv::Mat &camera_frame) {
+  // Wrap Mat into an ImageFrame.
+  auto input_frame = absl::make_unique<mediapipe::ImageFrame>(
+      mediapipe::ImageFormat::SRGB, camera_frame.cols, camera_frame.rows,
+      mediapipe::ImageFrame::kDefaultAlignmentBoundary);
+  cv::Mat input_frame_mat = mediapipe::formats::MatView(input_frame.get());
+  camera_frame.copyTo(input_frame_mat);
+
+  // Send image packet into the graph.
+
+  size_t frame_timestamp_us =
+      (double)cv::getTickCount() / (double)cv::getTickFrequency() * 1e6;
+  MP_RETURN_IF_ERROR(graph.AddPacketToInputStream(
+      kInputStream, mediapipe::Adopt(input_frame.release())
+                        .At(mediapipe::Timestamp(frame_timestamp_us))));
+  LOG(INFO) << "Pushed new frame.";
+
+#ifdef DEBUG
+  LOG(INFO) << "Pushed new frame.";
+#endif
+  mediapipe::Packet face_count_packet;
+  if (!face_count_poller_ptr ||
+      !face_count_poller_ptr->Next(&face_count_packet)) {
+    LOG(INFO) << "Failed during getting next face_count_packet.";
+
+    return absl::Status();
+  }
+  auto &face_count = face_count_packet.Get<int>();
+
+#ifdef DEBUG
+  LOG(INFO) << "Got face_count: " << face_count;
+#endif
+
+  if (!face_count) {
+    return absl::Status();
+  }
+
+  mediapipe::Packet face_landmarks_packet;
+  if (!landmarks_poller_ptr ||
+      !landmarks_poller_ptr->Next(&face_landmarks_packet)) {
+    LOG(INFO) << "Failed during getting next landmarks_packet.";
+
+    return absl::Status();
+  }
+
+  auto &output_landmarks_vector =
+      face_landmarks_packet
+          .Get<::std::vector<::mediapipe::NormalizedLandmarkList>>();
+
+  auto &output_landmarks = output_landmarks_vector[0];
+
+#ifdef DEBUG
+  LOG(INFO) << "Got landmarks_packet: " << output_landmarks.landmark_size();
+#endif
+
+  auto &landmark = output_landmarks.landmark(0);
+#ifdef DEBUG
+  LOG(INFO) << "First landmark: x - " << landmark.x() << ", y - "
+            << landmark.y() << ", z - " << landmark.z();
+#endif
+
+  return absl::Status();
+}
+
+std::vector<cv::Point2f> *
+FaceMeshDetector::ProcessFrame(cv::Mat &camera_frame) {
+  ProcessFrameWithStatus(camera_frame);
+
+  return new std::vector<cv::Point2f>();
+}
+
+extern "C" {
+DLLEXPORT FaceMeshDetector *FaceMeshDetector_Construct() {
+  return new FaceMeshDetector();
+}
+
+DLLEXPORT void FaceMeshDetector_Destruct(FaceMeshDetector *detector) {
+  delete detector;
+}
+
+DLLEXPORT void *FaceMeshDetector_ProcessFrame(FaceMeshDetector *detector,
+                                              cv::Mat &camera_frame) {
+  return reinterpret_cast<void *>(detector->ProcessFrame(camera_frame));
+}
+}
+
+const char FaceMeshDetector::kInputStream[] = "input_video";
+const char FaceMeshDetector::kOutputStream_landmarks[] = "multi_face_landmarks";
+const char FaceMeshDetector::kOutputStream_faceCount[] = "face_count";
+
+const std::string FaceMeshDetector::graphConfig = R"pb(
+# MediaPipe graph that performs face mesh with TensorFlow Lite on CPU.
+
+# Input image. (ImageFrame)
+input_stream: "input_video"
+
+# Collection of detected/processed faces, each represented as a list of
+# landmarks. (std::vector<NormalizedLandmarkList>)
+output_stream: "multi_face_landmarks"
+
+# Detected faces count. (int)
+output_stream: "face_count"
+
+node {
+  calculator: "FlowLimiterCalculator"
+  input_stream: "input_video"
+  input_stream: "FINISHED:multi_face_landmarks"
+  input_stream_info: {
+    tag_index: "FINISHED"
+    back_edge: true
+  }
+  output_stream: "throttled_input_video"
+}
+
+# Defines side packets for further use in the graph.
+node {
+  calculator: "ConstantSidePacketCalculator"
+  output_side_packet: "PACKET:num_faces"
+  node_options: {
+    [type.googleapis.com/mediapipe.ConstantSidePacketCalculatorOptions]: {
+      packet { int_value: 1 }
+    }
+  }
+}
+
+# Subgraph that detects faces and corresponding landmarks.
+node {
+  calculator: "FaceLandmarkFrontCpuWithFaceCounter"
+  input_stream: "IMAGE:throttled_input_video"
+  input_side_packet: "NUM_FACES:num_faces"
+  output_stream: "LANDMARKS:multi_face_landmarks"
+  output_stream: "ROIS_FROM_LANDMARKS:face_rects_from_landmarks"
+  output_stream: "DETECTIONS:face_detections"
+  output_stream: "ROIS_FROM_DETECTIONS:face_rects_from_detections"
+  output_stream: "FACE_COUNT_FROM_LANDMARKS:face_count"
+}
+
+)pb";

--- a/mediapipe/examples/desktop/face_mesh_dll/face_mesh_lib.h
+++ b/mediapipe/examples/desktop/face_mesh_dll/face_mesh_lib.h
@@ -1,0 +1,64 @@
+#ifndef FACE_MESH_LIBRARY_H
+#define FACE_MESH_LIBRARY_H
+
+#ifdef COMPILING_DLL
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT __declspec(dllimport)
+#endif
+
+#include <cstdlib>
+#include <string>
+#include <memory>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "mediapipe/framework/calculator_framework.h"
+#include "mediapipe/framework/calculator_graph.h"
+#include "mediapipe/framework/formats/image_frame.h"
+#include "mediapipe/framework/formats/image_frame_opencv.h"
+#include "mediapipe/framework/formats/landmark.pb.h"
+#include "mediapipe/framework/port/file_helpers.h"
+#include "mediapipe/framework/port/opencv_highgui_inc.h"
+#include "mediapipe/framework/port/opencv_imgproc_inc.h"
+#include "mediapipe/framework/port/opencv_video_inc.h"
+#include "mediapipe/framework/port/parse_text_proto.h"
+#include "mediapipe/framework/port/status.h"
+
+class FaceMeshDetector {
+public:
+  FaceMeshDetector();
+  ~FaceMeshDetector() = default;
+  std::vector<cv::Point2f> *ProcessFrame(cv::Mat &camera_frame);
+
+private:
+  absl::Status InitFaceMeshDetector();
+  absl::Status ProcessFrameWithStatus(cv::Mat &camera_frame);
+
+  static const char kInputStream[];
+  static const char kOutputStream_landmarks[];
+  static const char kOutputStream_faceCount[];
+
+  static const std::string graphConfig;
+
+  mediapipe::CalculatorGraph graph;
+  
+  std::unique_ptr<mediapipe::OutputStreamPoller> landmarks_poller_ptr;
+  std::unique_ptr<mediapipe::OutputStreamPoller> face_count_poller_ptr;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DLLEXPORT FaceMeshDetector *FaceMeshDetector_Construct();
+
+DLLEXPORT void FaceMeshDetector_Destruct(FaceMeshDetector *detector);
+
+DLLEXPORT void *FaceMeshDetector_ProcessFrame(FaceMeshDetector *detector,
+                                              cv::Mat &camera_frame);
+
+#ifdef __cplusplus
+};
+#endif
+#endif

--- a/mediapipe/examples/desktop/face_mesh_dll/face_mesh_lib.h
+++ b/mediapipe/examples/desktop/face_mesh_dll/face_mesh_lib.h
@@ -8,8 +8,8 @@
 #endif
 
 #include <cstdlib>
-#include <string>
 #include <memory>
+#include <string>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
@@ -29,11 +29,14 @@ class FaceMeshDetector {
 public:
   FaceMeshDetector();
   ~FaceMeshDetector() = default;
-  std::vector<cv::Point2f> *ProcessFrame(cv::Mat &camera_frame);
+  std::vector<std::vector<cv::Point2f>> *ProcessFrame2D(cv::Mat &camera_frame);
 
 private:
   absl::Status InitFaceMeshDetector();
-  absl::Status ProcessFrameWithStatus(cv::Mat &camera_frame);
+  absl::Status
+  ProcessFrameWithStatus(cv::Mat &camera_frame,
+                         std::unique_ptr<std::vector<std::vector<cv::Point2f>>>
+                             &multi_face_landmarks);
 
   static const char kInputStream[];
   static const char kOutputStream_landmarks[];
@@ -42,7 +45,7 @@ private:
   static const std::string graphConfig;
 
   mediapipe::CalculatorGraph graph;
-  
+
   std::unique_ptr<mediapipe::OutputStreamPoller> landmarks_poller_ptr;
   std::unique_ptr<mediapipe::OutputStreamPoller> face_count_poller_ptr;
 };
@@ -55,8 +58,8 @@ DLLEXPORT FaceMeshDetector *FaceMeshDetector_Construct();
 
 DLLEXPORT void FaceMeshDetector_Destruct(FaceMeshDetector *detector);
 
-DLLEXPORT void *FaceMeshDetector_ProcessFrame(FaceMeshDetector *detector,
-                                              cv::Mat &camera_frame);
+DLLEXPORT void *FaceMeshDetector_ProcessFrame2D(FaceMeshDetector *detector,
+                                                cv::Mat &camera_frame);
 
 #ifdef __cplusplus
 };

--- a/mediapipe/examples/desktop/face_mesh_dll/windows_dll_library.bzl
+++ b/mediapipe/examples/desktop/face_mesh_dll/windows_dll_library.bzl
@@ -1,0 +1,62 @@
+"""
+This is a simple windows_dll_library rule for builing a DLL Windows
+that can be depended on by other cc rules.
+Example useage:
+  windows_dll_library(
+      name = "hellolib",
+      srcs = [
+          "hello-library.cpp",
+      ],
+      hdrs = ["hello-library.h"],
+      # Define COMPILING_DLL to export symbols during compiling the DLL.
+      copts = ["/DCOMPILING_DLL"],
+  )
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library")
+
+def windows_dll_library(
+        name,
+        srcs = [],
+        deps = [],
+        hdrs = [],
+        visibility = None,
+        **kwargs):
+    """A simple windows_dll_library rule for builing a DLL Windows."""
+    dll_name = name + ".dll"
+    import_lib_name = name + "_import_lib"
+    import_target_name = name + "_dll_import"
+
+    # Build the shared library
+    cc_binary(
+        name = dll_name,
+        srcs = srcs + hdrs,
+        deps = deps,
+        linkshared = 1,
+        **kwargs
+    )
+
+    # Get the import library for the dll
+    native.filegroup(
+        name = import_lib_name,
+        srcs = [":" + dll_name],
+        output_group = "interface_library",
+    )
+
+    # Because we cannot directly depend on cc_binary from other cc rules in deps attribute,
+    # we use cc_import as a bridge to depend on the dll.
+    cc_import(
+        name = import_target_name,
+        interface_library = ":" + import_lib_name,
+        shared_library = ":" + dll_name,
+    )
+
+    # Create a new cc_library to also include the headers needed for the shared library
+    cc_library(
+        name = name,
+        hdrs = hdrs,
+        visibility = visibility,
+        deps = deps + [
+            ":" + import_target_name,
+        ],
+    )

--- a/mediapipe/modules/face_landmark/BUILD
+++ b/mediapipe/modules/face_landmark/BUILD
@@ -75,6 +75,28 @@ mediapipe_simple_subgraph(
 )
 
 mediapipe_simple_subgraph(
+    name = "face_landmark_front_cpu_with_face_counter",
+    graph = "face_landmark_front_cpu_with_face_counter.pbtxt",
+    register_as = "FaceLandmarkFrontCpuWithFaceCounter",
+    deps = [
+        ":face_detection_front_detection_to_roi",
+        ":face_landmark_cpu",
+        ":face_landmark_landmarks_to_roi",
+        "//mediapipe/calculators/core:begin_loop_calculator",
+        "//mediapipe/calculators/core:clip_vector_size_calculator",
+        "//mediapipe/calculators/core:constant_side_packet_calculator",
+        "//mediapipe/calculators/core:end_loop_calculator",
+        "//mediapipe/calculators/core:gate_calculator",
+        "//mediapipe/calculators/core:previous_loopback_calculator",
+        "//mediapipe/calculators/image:image_properties_calculator",
+        "//mediapipe/calculators/util:association_norm_rect_calculator",
+        "//mediapipe/calculators/util:collection_has_min_size_calculator",
+        "//mediapipe/calculators/util:counting_vector_size_calculator",
+        "//mediapipe/modules/face_detection:face_detection_short_range_cpu",
+    ],
+)
+
+mediapipe_simple_subgraph(
     name = "face_landmark_front_gpu",
     graph = "face_landmark_front_gpu.pbtxt",
     register_as = "FaceLandmarkFrontGpu",

--- a/mediapipe/modules/face_landmark/face_landmark_front_cpu_with_face_counter.pbtxt
+++ b/mediapipe/modules/face_landmark/face_landmark_front_cpu_with_face_counter.pbtxt
@@ -1,0 +1,249 @@
+# MediaPipe graph to detect/predict face landmarks. (CPU input, and inference is
+# executed on CPU.) This graph tries to skip face detection as much as possible
+# by using previously detected/predicted landmarks for new images.
+#
+# It is required that "face_detection_short_range.tflite" is available at
+# "mediapipe/modules/face_detection/face_detection_short_range.tflite"
+# path during execution.
+#
+# It is required that "face_landmark.tflite" is available at
+# "mediapipe/modules/face_landmark/face_landmark.tflite"
+# path during execution.
+#
+# EXAMPLE:
+#   node {
+#     calculator: "FaceLandmarkFrontCpu"
+#     input_stream: "IMAGE:image"
+#     input_side_packet: "NUM_FACES:num_faces"
+#     output_stream: "LANDMARKS:multi_face_landmarks"
+#   }
+
+type: "FaceLandmarkFrontCpu"
+
+# CPU image. (ImageFrame)
+input_stream: "IMAGE:image"
+
+# Max number of faces to detect/track. (int)
+input_side_packet: "NUM_FACES:num_faces"
+
+# Collection of detected/predicted faces, each represented as a list of 468 face
+# landmarks. (std::vector<NormalizedLandmarkList>)
+# NOTE: there will not be an output packet in the LANDMARKS stream for this
+# particular timestamp if none of faces detected. However, the MediaPipe
+# framework will internally inform the downstream calculators of the absence of
+# this packet so that they don't wait for it unnecessarily.
+output_stream: "LANDMARKS:multi_face_landmarks"
+
+# Extra outputs (for debugging, for instance).
+# Detected faces. (std::vector<Detection>)
+output_stream: "DETECTIONS:face_detections"
+# Regions of interest calculated based on landmarks.
+# (std::vector<NormalizedRect>)
+output_stream: "ROIS_FROM_LANDMARKS:face_rects_from_landmarks"
+# Regions of interest calculated based on face detections.
+# (std::vector<NormalizedRect>)
+output_stream: "ROIS_FROM_DETECTIONS:face_rects_from_detections"
+
+# (int)
+output_stream: "FACE_COUNT_FROM_LANDMARKS:face_count"
+
+
+# Defines whether landmarks on the previous image should be used to help
+# localize landmarks on the current image.
+node {
+  name: "ConstantSidePacketCalculator"
+  calculator: "ConstantSidePacketCalculator"
+  output_side_packet: "PACKET:use_prev_landmarks"
+  options: {
+    [mediapipe.ConstantSidePacketCalculatorOptions.ext]: {
+      packet { bool_value: true }
+    }
+  }
+}
+node {
+  calculator: "GateCalculator"
+  input_side_packet: "ALLOW:use_prev_landmarks"
+  input_stream: "prev_face_rects_from_landmarks"
+  output_stream: "gated_prev_face_rects_from_landmarks"
+}
+
+# Determines if an input vector of NormalizedRect has a size greater than or
+# equal to the provided num_faces.
+node {
+  calculator: "NormalizedRectVectorHasMinSizeCalculator"
+  input_stream: "ITERABLE:gated_prev_face_rects_from_landmarks"
+  input_side_packet: "num_faces"
+  output_stream: "prev_has_enough_faces"
+}
+
+# Drops the incoming image if enough faces have already been identified from the
+# previous image. Otherwise, passes the incoming image through to trigger a new
+# round of face detection.
+node {
+  calculator: "GateCalculator"
+  input_stream: "image"
+  input_stream: "DISALLOW:prev_has_enough_faces"
+  output_stream: "gated_image"
+  options: {
+    [mediapipe.GateCalculatorOptions.ext] {
+      empty_packets_as_allow: true
+    }
+  }
+}
+
+# Detects faces.
+node {
+  calculator: "FaceDetectionShortRangeCpu"
+  input_stream: "IMAGE:gated_image"
+  output_stream: "DETECTIONS:all_face_detections"
+}
+
+# Makes sure there are no more detections than the provided num_faces.
+node {
+  calculator: "ClipDetectionVectorSizeCalculator"
+  input_stream: "all_face_detections"
+  output_stream: "face_detections"
+  input_side_packet: "num_faces"
+}
+
+# Calculate size of the image.
+node {
+  calculator: "ImagePropertiesCalculator"
+  input_stream: "IMAGE:gated_image"
+  output_stream: "SIZE:gated_image_size"
+}
+
+# Outputs each element of face_detections at a fake timestamp for the rest of
+# the graph to process. Clones the image size packet for each face_detection at
+# the fake timestamp. At the end of the loop, outputs the BATCH_END timestamp
+# for downstream calculators to inform them that all elements in the vector have
+# been processed.
+node {
+  calculator: "BeginLoopDetectionCalculator"
+  input_stream: "ITERABLE:face_detections"
+  input_stream: "CLONE:gated_image_size"
+  output_stream: "ITEM:face_detection"
+  output_stream: "CLONE:detections_loop_image_size"
+  output_stream: "BATCH_END:detections_loop_end_timestamp"
+}
+
+# Calculates region of interest based on face detections, so that can be used
+# to detect landmarks.
+node {
+  calculator: "FaceDetectionFrontDetectionToRoi"
+  input_stream: "DETECTION:face_detection"
+  input_stream: "IMAGE_SIZE:detections_loop_image_size"
+  output_stream: "ROI:face_rect_from_detection"
+}
+
+# Counting a multi_faceLandmarks vector size. The image stream is only used to 
+# make the calculator work even when there is no input vector.
+node {
+  calculator: "CountingNormalizedLandmarkListVectorSizeCalculator"
+  input_stream: "CLOCK:image"
+  input_stream: "VECTOR:multi_face_landmarks"
+  output_stream: "COUNT:face_count"
+}
+
+
+# Collects a NormalizedRect for each face into a vector. Upon receiving the
+# BATCH_END timestamp, outputs the vector of NormalizedRect at the BATCH_END
+# timestamp.
+node {
+  calculator: "EndLoopNormalizedRectCalculator"
+  input_stream: "ITEM:face_rect_from_detection"
+  input_stream: "BATCH_END:detections_loop_end_timestamp"
+  output_stream: "ITERABLE:face_rects_from_detections"
+}
+
+# Performs association between NormalizedRect vector elements from previous
+# image and rects based on face detections from the current image. This
+# calculator ensures that the output face_rects vector doesn't contain
+# overlapping regions based on the specified min_similarity_threshold.
+node {
+  calculator: "AssociationNormRectCalculator"
+  input_stream: "face_rects_from_detections"
+  input_stream: "gated_prev_face_rects_from_landmarks"
+  output_stream: "face_rects"
+  options: {
+    [mediapipe.AssociationCalculatorOptions.ext] {
+      min_similarity_threshold: 0.5
+    }
+  }
+}
+
+# Calculate size of the image.
+node {
+  calculator: "ImagePropertiesCalculator"
+  input_stream: "IMAGE:image"
+  output_stream: "SIZE:image_size"
+}
+
+# Outputs each element of face_rects at a fake timestamp for the rest of the
+# graph to process. Clones image and image size packets for each
+# single_face_rect at the fake timestamp. At the end of the loop, outputs the
+# BATCH_END timestamp for downstream calculators to inform them that all
+# elements in the vector have been processed.
+node {
+  calculator: "BeginLoopNormalizedRectCalculator"
+  input_stream: "ITERABLE:face_rects"
+  input_stream: "CLONE:0:image"
+  input_stream: "CLONE:1:image_size"
+  output_stream: "ITEM:face_rect"
+  output_stream: "CLONE:0:landmarks_loop_image"
+  output_stream: "CLONE:1:landmarks_loop_image_size"
+  output_stream: "BATCH_END:landmarks_loop_end_timestamp"
+}
+
+# Detects face landmarks within specified region of interest of the image.
+node {
+  calculator: "FaceLandmarkCpu"
+  input_stream: "IMAGE:landmarks_loop_image"
+  input_stream: "ROI:face_rect"
+  output_stream: "LANDMARKS:face_landmarks"
+}
+
+# Calculates region of interest based on face landmarks, so that can be reused
+# for subsequent image.
+node {
+  calculator: "FaceLandmarkLandmarksToRoi"
+  input_stream: "LANDMARKS:face_landmarks"
+  input_stream: "IMAGE_SIZE:landmarks_loop_image_size"
+  output_stream: "ROI:face_rect_from_landmarks"
+}
+
+# Collects a set of landmarks for each face into a vector. Upon receiving the
+# BATCH_END timestamp, outputs the vector of landmarks at the BATCH_END
+# timestamp.
+node {
+  calculator: "EndLoopNormalizedLandmarkListVectorCalculator"
+  input_stream: "ITEM:face_landmarks"
+  input_stream: "BATCH_END:landmarks_loop_end_timestamp"
+  output_stream: "ITERABLE:multi_face_landmarks"
+}
+
+# Collects a NormalizedRect for each face into a vector. Upon receiving the
+# BATCH_END timestamp, outputs the vector of NormalizedRect at the BATCH_END
+# timestamp.
+node {
+  calculator: "EndLoopNormalizedRectCalculator"
+  input_stream: "ITEM:face_rect_from_landmarks"
+  input_stream: "BATCH_END:landmarks_loop_end_timestamp"
+  output_stream: "ITERABLE:face_rects_from_landmarks"
+}
+
+# Caches face rects calculated from landmarks, and upon the arrival of the next
+# input image, sends out the cached rects with timestamps replaced by that of
+# the input image, essentially generating a packet that carries the previous
+# face rects. Note that upon the arrival of the very first input image, a
+# timestamp bound update occurs to jump start the feedback loop.
+node {
+  calculator: "PreviousLoopbackCalculator"
+  input_stream: "MAIN:image"
+  input_stream: "LOOP:face_rects_from_landmarks"
+  input_stream_info: {
+    tag_index: "LOOP"
+    back_edge: true
+  }
+  output_stream: "PREV_LOOP:prev_face_rects_from_landmarks"
+}


### PR DESCRIPTION
Change List:
- added face counter with "clock" (the trigger that allows to track all input events)
- face counter can be used for checking whether the face was detected (can be used as a flag to get face landmarks from the output stream)
- added `'face_mesh_dll/face_mesh_lib` that will be built as windows dynamic library
- added 'face_mesh_dll/face_mesh_cpu.cpp`  as simple test of  `'face_mesh_dll/face_mesh_lib`
- currently, face_mesh_lib only prints in console `face_count` and `first face landmark`
- FaceMeshDetector::ProcessFrame2D returns a pointer to vector with all face landmarks
- added converting of `mediapipe::NormalizedLandmarkList` to `std::vector<cv::Point2f>` to make more independent of mediapipe (to use in custom projects)